### PR TITLE
Change relationship harvesting error

### DIFF
--- a/app/db/models/harvesting.py
+++ b/app/db/models/harvesting.py
@@ -39,13 +39,13 @@ class Harvesting(Base):
         nullable=False, index=True, default=State.IDLE.value
     )
 
-    reference_events: Mapped[
-        List["app.db.models.reference_event.ReferenceEvent"]
-    ] = relationship(
-        "app.db.models.reference_event.ReferenceEvent",
-        back_populates="harvesting",
-        cascade="all, delete",
-        lazy="joined",
+    reference_events: Mapped[List["app.db.models.reference_event.ReferenceEvent"]] = (
+        relationship(
+            "app.db.models.reference_event.ReferenceEvent",
+            back_populates="harvesting",
+            cascade="all, delete",
+            lazy="joined",
+        )
     )
 
     # boolean field "history"
@@ -53,8 +53,10 @@ class Harvesting(Base):
 
     timestamp: Mapped[datetime] = Column(DateTime, default=datetime.utcnow)
 
-    error: Mapped["app.db.models.harvesting_error.HarvestingError"] = relationship(
-        "app.db.models.harvesting_error.HarvestingError",
-        cascade="all, delete-orphan",
-        lazy="joined",
+    error: Mapped[List["app.db.models.harvesting_error.HarvestingError"]] = (
+        relationship(
+            "app.db.models.harvesting_error.HarvestingError",
+            cascade="all, delete-orphan",
+            lazy="joined",
+        )
     )

--- a/app/models/harvesting.py
+++ b/app/models/harvesting.py
@@ -17,4 +17,4 @@ class Harvesting(BaseModel):
     state: str
 
     reference_events: List[ReferenceEvent] = []
-    error: HarvestingError | None
+    error: List[HarvestingError] | None

--- a/tests/test_api/test_amqp/test_amqp_message_publisher.py
+++ b/tests/test_api/test_amqp/test_amqp_message_publisher.py
@@ -28,7 +28,7 @@ async def test_publish_harvesting_status(
     expected_sent_message_payload = {
         "harvester": "idref",
         "state": "running",
-        "error": None,
+        "error": [],
         "entity": {
             "identifiers": [{"type": "idref", "value": "123456789"}],
             "name": "John Doe",


### PR DESCRIPTION
Because of async, there can be more of 1 error for 1 harvesting, so we put the relationship as 1-n