### PR TITLE
Raise UnexpectedFormatException when Title is not set in Science Plus reference

### DIFF
--- a/app/harvesters/abstract_references_converter.py
+++ b/app/harvesters/abstract_references_converter.py
@@ -25,9 +25,6 @@ from app.db.models.organization import Organization
 from app.db.models.reference import Reference
 from app.db.session import async_session
 from app.harvesters.abstract_harvester_raw_result import AbstractHarvesterRawResult
-from app.harvesters.exceptions.unexpected_format_exception import (
-    UnexpectedFormatException,
-)
 from app.services.concepts.concept_factory import ConceptFactory
 from app.services.concepts.concept_informations import ConceptInformations
 from app.services.concepts.dereferencing_error import DereferencingError
@@ -146,7 +143,7 @@ class AbstractReferencesConverter(ABC):
                     failed_fields.append(field)
 
             if failed_fields:
-                raise UnexpectedFormatException(
+                assert False, (
                     f"Validation failed in method {self.__class__.__name__}.{func.__name__}"
                     f" for reference: {ref.source_identifier}."
                     f" {', '.join(failed_fields)} should be set on reference"

--- a/app/harvesters/abstract_references_converter.py
+++ b/app/harvesters/abstract_references_converter.py
@@ -25,6 +25,9 @@ from app.db.models.organization import Organization
 from app.db.models.reference import Reference
 from app.db.session import async_session
 from app.harvesters.abstract_harvester_raw_result import AbstractHarvesterRawResult
+from app.harvesters.exceptions.unexpected_format_exception import (
+    UnexpectedFormatException,
+)
 from app.services.concepts.concept_factory import ConceptFactory
 from app.services.concepts.concept_informations import ConceptInformations
 from app.services.concepts.dereferencing_error import DereferencingError
@@ -143,7 +146,7 @@ class AbstractReferencesConverter(ABC):
                     failed_fields.append(field)
 
             if failed_fields:
-                assert False, (
+                raise UnexpectedFormatException(
                     f"Validation failed in method {self.__class__.__name__}.{func.__name__}"
                     f" for reference: {ref.source_identifier}."
                     f" {', '.join(failed_fields)} should be set on reference"

--- a/app/harvesters/idref/science_plus_references_converter.py
+++ b/app/harvesters/idref/science_plus_references_converter.py
@@ -7,6 +7,9 @@ from app.db.models.reference_identifier import ReferenceIdentifier
 from app.db.models.reference import Reference
 
 from app.db.models.title import Title
+from app.harvesters.exceptions.unexpected_format_exception import (
+    UnexpectedFormatException,
+)
 from app.harvesters.idref.abes_rdf_references_converter import (
     AbesRDFReferencesConverter,
 )
@@ -48,6 +51,10 @@ class SciencePlusReferencesConverter(AbesRDFReferencesConverter):
         self.pub_graph = raw_data.payload
         self.uri = raw_data.source_identifier
         await super().convert(raw_data=raw_data, new_ref=new_ref)
+        if not new_ref.titles:
+            raise UnexpectedFormatException(
+                f"Science Plus reference without title: {new_ref.source_identifier}"
+            )
         if raw_data.doi:
             new_ref.identifiers.append(self._add_doi_identifier(raw_data.doi))
 

--- a/tests/data/science_plus_rdf/science_plus_document_without_title.rdf
+++ b/tests/data/science_plus_rdf/science_plus_document_without_title.rdf
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<rdf:RDF
+	xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+	xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+	xmlns:dcterms="http://purl.org/dc/terms/"
+	xmlns:rdaw="http://rdaregistry.info/Elements/w/"
+	xmlns:vivo="http://vivoweb.org/ontology/core#"
+	xmlns:hub="http://hub.abes.fr/namespace/" >
+  <rdf:Description rdf:about="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/w">
+    <rdf:type rdf:resource="http://purl.org/ontology/bibo/Article" />
+    <rdf:type rdf:resource="http://rdaregistry.info/Elements/c/C10001" />
+    <dcterms:isPartOf rdf:resource="http://hub.abes.fr/springer/periodical/10571/1992/volume_12/issue_1/w" />
+    <dcterms:subject rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/subject/environnement" />
+    <dcterms:subject rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/subject/metropolisation" />
+    <dcterms:subject rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/subject/metropolization" />
+    <dcterms:subject rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/subject/periurbanisation" />
+    <dcterms:subject rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/subject/periurbanization" />
+    <dcterms:subject rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/subject/durabilite" />
+    <dcterms:subject rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/subject/environment" />
+    <dcterms:subject rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/subject/sustainability" />
+    <rdaw:P10072 rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/m/web" />
+    <rdaw:P10072 rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/m/print" />
+    <vivo:relatedBy rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/authorship/2" />
+    <vivo:relatedBy rdf:resource="http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/D33AF39D3B7834E0E053120B220A2036/authorship/1" />
+    <dcterms:abstract xml:lang="en">Urban fringes, rural fringes between Santiago de Chile and Valparaíso. The Cordillera de la Costa, between Santiago de Chile and Valparaíso, has seen its accessibility improve rapidly, giving urban populations access to a space that was hitherto remote. The metropolitan expansion of Santiago and economic growth make it a space to conquer. Its conquest is mainly the work of actions of the private sphere, as much agricultural entrepreneurs, property companies and tourist firms as new private residents. The process as a whole socially marginalizes local populations. In the absence of a unified regional land plan, the fringe appears as a space where anything is still possible, but with negative consequences for urban sustainability.</dcterms:abstract>
+    <dcterms:abstract xml:lang="fr">La Cordillère de la Côte, entre Santiago du Chili et Valparaíso a vu son accessibilité s’améliorer rapidement, donnant aux populations urbaines accès à un espace jusqu’alors isolé. L’expansion métropolitaine de Santiago et la croissance économique en font un espace à conquérir. Sa conquête est principalement le fait des acteurs privés, aussi bien les entrepreneurs agricoles, immobiliers et touristiques que les nouveaux résidents. Cette conquête marginalise socialement les populations locales. En l’absence d’un projet de territoire unifié, la marge apparaît comme un espace où tout est encore possible, mais avec des conséquences négatives sur la durabilité métropolitaine.</dcterms:abstract>
+    <hub:articleType rdf:resource="http://hub.abes.fr/cairn/periodical/cairn_typeart/articlederevue" />
+    <hub:isPartOfThisJournal rdf:resource="http://hub.abes.fr/springer/periodical/10571/w" />
+    <hub:publisher-id>AUTR_045_0207</hub:publisher-id>
+  </rdf:Description>
+</rdf:RDF>

--- a/tests/fixtures/science_plus_rdf_docs_fixtures.py
+++ b/tests/fixtures/science_plus_rdf_docs_fixtures.py
@@ -7,6 +7,21 @@ from app.harvesters.idref.idref_harvester import IdrefHarvester
 from app.harvesters.rdf_harvester_raw_result import RdfHarvesterRawResult as RdfResult
 
 
+@pytest.fixture(name="science_plus_rdf_result_without_title")
+def fixture_science_plus_rdf_result_without_title(
+    science_plus_rdf_graph_for_doc_without_title,
+) -> RdfResult:
+    """Rdf result from science plus wrapped in a RdfHarvesterRawResult without title"""
+    return RdfResult(
+        payload=science_plus_rdf_graph_for_doc_without_title,
+        source_identifier=URIRef(
+            "http://hub.abes.fr/cairn/periodical/autr/2008/issue_autr045/"
+            "D33AF39D3B7834E0E053120B220A2036/w"
+        ),
+        formatter_name=IdrefHarvester.Formatters.SCIENCE_PLUS_RDF.value,
+    )
+
+
 @pytest.fixture(name="science_plus_rdf_result_for_doc")
 def fixture_science_plus_rdf_result_for_doc(
     science_plus_rdf_graph_for_doc,
@@ -19,6 +34,14 @@ def fixture_science_plus_rdf_result_for_doc(
             "D33AF39D3B7834E0E053120B220A2036/w"
         ),
         formatter_name=IdrefHarvester.Formatters.SCIENCE_PLUS_RDF.value,
+    )
+
+
+@pytest.fixture(name="science_plus_rdf_graph_for_doc_without_title")
+def fixture_science_plus_rdf_graph_for_doc_without_title(_base_path) -> Graph:
+    """Rdf graph from science plus rdf file without title"""
+    return _science_plus_rdf_graph_from_file(
+        _base_path, "science_plus_document_without_title"
     )
 
 

--- a/tests/test_harvesters/test_abstract_references_converter_validate.py
+++ b/tests/test_harvesters/test_abstract_references_converter_validate.py
@@ -11,9 +11,6 @@ from app.db.models.reference import Reference as DbReference
 from app.db.models.subtitle import Subtitle as DbSubtitle
 from app.db.models.title import Title as DbTitle
 from app.harvesters.abstract_references_converter import AbstractReferencesConverter
-from app.harvesters.exceptions.unexpected_format_exception import (
-    UnexpectedFormatException,
-)
 
 
 @pytest.fixture(name="reference_without_title")
@@ -95,7 +92,7 @@ async def test_reference_without_title_raises_exception(reference_without_title)
     """
     Given a reference without title
     When the validate_reference decorator is called
-    Then an UnexpectedFormatException should be raised
+    Then an AssertionError should be raised
 
     :param reference_without_title: A reference without title
     """
@@ -106,7 +103,7 @@ async def test_reference_without_title_raises_exception(reference_without_title)
     function_with_decorator = AbstractReferencesConverter.validate_reference(
         decorated_function
     )
-    with pytest.raises(UnexpectedFormatException) as exc_info:
+    with pytest.raises(AssertionError) as exc_info:
         await function_with_decorator(
             AbstractReferencesConverter, new_ref=reference_without_title
         )
@@ -147,7 +144,7 @@ async def test_reference_without_harvester_raises_exception(
     """ "
     Given a reference without identifier
     When the validate_reference decorator is called
-    Then an UnexpectedFormatException should be raised
+    Then an AssertionError should be raised
 
     :param reference_without_harvester: A reference without identifier
     """
@@ -158,7 +155,7 @@ async def test_reference_without_harvester_raises_exception(
     function_with_decorator = AbstractReferencesConverter.validate_reference(
         decorated_function
     )
-    with pytest.raises(UnexpectedFormatException) as exc_info:
+    with pytest.raises(AssertionError) as exc_info:
         await function_with_decorator(
             AbstractReferencesConverter, new_ref=reference_without_harvester
         )
@@ -173,7 +170,7 @@ async def test_reference_with_abstract_value_none_raises_exception(
     """
     Given a reference without identifier
     When the validate_reference decorator is called
-    Then an UnexpectedFormatException should be raised
+    Then an AssertionError should be raised
 
     :param reference_with_abstract_value_none: A reference without identifier
     """
@@ -184,7 +181,7 @@ async def test_reference_with_abstract_value_none_raises_exception(
     function_with_decorator = AbstractReferencesConverter.validate_reference(
         decorated_function
     )
-    with pytest.raises(UnexpectedFormatException) as exc_info:
+    with pytest.raises(AssertionError) as exc_info:
         await function_with_decorator(
             AbstractReferencesConverter, new_ref=reference_with_abstract_value_none
         )

--- a/tests/test_harvesters/test_abstract_references_converter_validate.py
+++ b/tests/test_harvesters/test_abstract_references_converter_validate.py
@@ -1,6 +1,7 @@
 """
 Test the validate_reference decorator of the AbstractReferencesConverter class.
 """
+
 import pytest
 
 from app.db.models.abstract import Abstract as DbAbstract
@@ -10,6 +11,9 @@ from app.db.models.reference import Reference as DbReference
 from app.db.models.subtitle import Subtitle as DbSubtitle
 from app.db.models.title import Title as DbTitle
 from app.harvesters.abstract_references_converter import AbstractReferencesConverter
+from app.harvesters.exceptions.unexpected_format_exception import (
+    UnexpectedFormatException,
+)
 
 
 @pytest.fixture(name="reference_without_title")
@@ -91,7 +95,7 @@ async def test_reference_without_title_raises_exception(reference_without_title)
     """
     Given a reference without title
     When the validate_reference decorator is called
-    Then an AssertionError should be raised
+    Then an UnexpectedFormatException should be raised
 
     :param reference_without_title: A reference without title
     """
@@ -102,7 +106,7 @@ async def test_reference_without_title_raises_exception(reference_without_title)
     function_with_decorator = AbstractReferencesConverter.validate_reference(
         decorated_function
     )
-    with pytest.raises(AssertionError) as exc_info:
+    with pytest.raises(UnexpectedFormatException) as exc_info:
         await function_with_decorator(
             AbstractReferencesConverter, new_ref=reference_without_title
         )
@@ -143,7 +147,7 @@ async def test_reference_without_harvester_raises_exception(
     """ "
     Given a reference without identifier
     When the validate_reference decorator is called
-    Then an AssertionError should be raised
+    Then an UnexpectedFormatException should be raised
 
     :param reference_without_harvester: A reference without identifier
     """
@@ -154,7 +158,7 @@ async def test_reference_without_harvester_raises_exception(
     function_with_decorator = AbstractReferencesConverter.validate_reference(
         decorated_function
     )
-    with pytest.raises(AssertionError) as exc_info:
+    with pytest.raises(UnexpectedFormatException) as exc_info:
         await function_with_decorator(
             AbstractReferencesConverter, new_ref=reference_without_harvester
         )
@@ -169,7 +173,7 @@ async def test_reference_with_abstract_value_none_raises_exception(
     """
     Given a reference without identifier
     When the validate_reference decorator is called
-    Then an AssertionError should be raised
+    Then an UnexpectedFormatException should be raised
 
     :param reference_with_abstract_value_none: A reference without identifier
     """
@@ -180,7 +184,7 @@ async def test_reference_with_abstract_value_none_raises_exception(
     function_with_decorator = AbstractReferencesConverter.validate_reference(
         decorated_function
     )
-    with pytest.raises(AssertionError) as exc_info:
+    with pytest.raises(UnexpectedFormatException) as exc_info:
         await function_with_decorator(
             AbstractReferencesConverter, new_ref=reference_with_abstract_value_none
         )

--- a/tests/test_harvesters/test_idref/test_science_plus_references_converter.py
+++ b/tests/test_harvesters/test_idref/test_science_plus_references_converter.py
@@ -1,3 +1,7 @@
+import pytest
+from app.harvesters.exceptions.unexpected_format_exception import (
+    UnexpectedFormatException,
+)
 from app.harvesters.idref.science_plus_references_converter import (
     SciencePlusReferencesConverter,
 )
@@ -48,3 +52,28 @@ async def test_science_plus_convert_for_rdf_result(
     assert test_reference.issue.volume == expected_volume
     assert test_reference.issue.number == expected_issue
     assert expected_journal_title in test_reference.issue.journal.titles
+
+
+async def test_science_plus_convert_for_rdf_without_title(
+    science_plus_rdf_result_without_title,
+):
+    """
+    GIVEN a SciencePlusReferencesConverter instance and a sudoc RDF result for a document
+    WHEN the convert method is called
+    THEN it should return a Reference instance with the expected values
+
+    :param science_plus_rdf_result_for_doc: a science plus RDF result for a document
+    :return: None
+    """
+    converter_under_tests = SciencePlusReferencesConverter()
+
+    test_reference = converter_under_tests.build(
+        raw_data=science_plus_rdf_result_without_title
+    )
+
+    with pytest.raises(UnexpectedFormatException) as exc_info:
+        await converter_under_tests.convert(
+            raw_data=science_plus_rdf_result_without_title, new_ref=test_reference
+        )
+
+    assert exc_info.match("titles should be set on reference")

--- a/tests/test_harvesters/test_idref/test_science_plus_references_converter.py
+++ b/tests/test_harvesters/test_idref/test_science_plus_references_converter.py
@@ -76,4 +76,4 @@ async def test_science_plus_convert_for_rdf_without_title(
             raw_data=science_plus_rdf_result_without_title, new_ref=test_reference
         )
 
-    assert exc_info.match("titles should be set on reference")
+    assert exc_info.match("Science Plus reference without title:")


### PR DESCRIPTION
@E-Bara @jdp1ps 

In the validate_reference decorator. I added a UnexpectedFormatException raise if there are any fields failed.
That way, the abstract_harvester can handle the error, and continue to convert other documents.