### PR TITLE
Generate message for "not applicable" harvester

### DIFF
--- a/app/db/models/harvesting.py
+++ b/app/db/models/harvesting.py
@@ -26,6 +26,7 @@ class Harvesting(Base):
         RUNNING = "running"
         COMPLETED = "completed"
         FAILED = "failed"
+        NOT_APPLICABLE = "not_applicable"
 
     # pylint: disable=C0103
     id: Mapped[int] = mapped_column(primary_key=True)
@@ -39,21 +40,21 @@ class Harvesting(Base):
         nullable=False, index=True, default=State.IDLE.value
     )
 
-    reference_events: Mapped[List["app.db.models.reference_event.ReferenceEvent"]] = (
-        relationship(
-            "app.db.models.reference_event.ReferenceEvent",
-            back_populates="harvesting",
-            cascade="all, delete",
-            lazy="joined",
-        )
+    reference_events: Mapped[
+        List["app.db.models.reference_event.ReferenceEvent"]
+    ] = relationship(
+        "app.db.models.reference_event.ReferenceEvent",
+        back_populates="harvesting",
+        cascade="all, delete",
+        lazy="joined",
     )
 
     timestamp: Mapped[datetime] = Column(DateTime, default=datetime.utcnow)
 
-    error: Mapped[List["app.db.models.harvesting_error.HarvestingError"]] = (
-        relationship(
-            "app.db.models.harvesting_error.HarvestingError",
-            cascade="all, delete-orphan",
-            lazy="joined",
-        )
+    error: Mapped[
+        List["app.db.models.harvesting_error.HarvestingError"]
+    ] = relationship(
+        "app.db.models.harvesting_error.HarvestingError",
+        cascade="all, delete-orphan",
+        lazy="joined",
     )

--- a/app/harvesters/abstract_harvester.py
+++ b/app/harvesters/abstract_harvester.py
@@ -225,6 +225,14 @@ class AbstractHarvester(ABC):  # pylint: disable=too-many-instance-attributes
             logger.error(f"Unexpected exception during harvester run : {e}")
             await self.handle_error(e, with_stack=True)
 
+    async def skip(self):
+        """
+        Skip the harvester execution
+        :return: None
+        """
+        await self._update_harvesting_state(Harvesting.State.NOT_APPLICABLE)
+        await self._notify_harvesting_state()
+
     async def _handle_converted_result(
         self,
         new_ref: Reference,

--- a/app/harvesters/idref/idref_harvester.py
+++ b/app/harvesters/idref/idref_harvester.py
@@ -95,6 +95,11 @@ class IdrefHarvester(AbstractHarvester):
                 if doc["secondary_source"] is None:
                     continue
                 coro = self._secondary_query_process(doc)
+                if coro is None:
+                    logger.error(
+                        f"No harvester available for source {doc['secondary_source']}"
+                    )
+                    continue
                 # Temporary semi-sequential implementation
                 # Sudoc server does not support parallel querying beyond 5 parallel requests
                 # See issue #251
@@ -143,6 +148,11 @@ class IdrefHarvester(AbstractHarvester):
                 if doc["secondary_source"] == "SUDOC":
                     continue
                 coro = self._secondary_query_process(doc)
+                if coro is None:
+                    logger.error(
+                        f"No harvester available for source {doc['secondary_source']}"
+                    )
+                    continue
                 pending_queries.add(asyncio.create_task(coro))
                 while pending_queries:
                     pub = None

--- a/app/services/retrieval/retrieval_service.py
+++ b/app/services/retrieval/retrieval_service.py
@@ -121,14 +121,12 @@ class RetrievalService:
         pending_harvesters = []
         harvesting_tasks_index = {}
         for harvester_name, harvester in self.harvesters.items():
-            if not harvester.is_relevant(self.entity):
-                continue
             async with async_session() as session:
                 async with session.begin():
                     harvesting = await HarvestingDAO(session).create_harvesting(
                         retrieval=self.retrieval,
                         harvester=harvester_name,
-                        state=Harvesting.State.RUNNING,
+                        state=Harvesting.State.IDLE,
                     )
             if result_queue is not None:
                 harvester.set_result_queue(result_queue)
@@ -136,8 +134,11 @@ class RetrievalService:
             harvester.set_event_types(self.retrieval.event_types)
             harvester.set_fetch_enhancements(self.fetch_enhancements)
             harvester.set_harvesting_id(harvesting.id)
+            action = (
+                harvester.run if harvester.is_relevant(self.entity) else harvester.skip
+            )
             task = asyncio.create_task(
-                harvester.run(),
+                action(),
                 name=f"{harvester_name}_harvester_retrieval_{self.retrieval.id}",
             )
             pending_harvesters.append(task)

--- a/app/svp_harvester.py
+++ b/app/svp_harvester.py
@@ -18,6 +18,8 @@ from app.gui.routes.gui import router as gui_router
 from app.http.aio_http_client_manager import AioHttpClientManager
 from app.models.custom_medatata import register_custom_metadata_schemas
 from app.redis.redis_pool import RedisPool
+
+# from app.redis.fake_redis_pool import FakeRedisPool as RedisPool
 from app.settings.app_env_types import AppEnvTypes
 
 

--- a/app/templates/src/js/retrieve/control.js
+++ b/app/templates/src/js/retrieve/control.js
@@ -113,7 +113,7 @@ class Control {
     finished(retrieval) {
         let completed = true;
         for (const harvesting of retrieval.harvestings) {
-            if (["completed", "failed"].indexOf(harvesting.state) === -1) {
+            if (["completed", "failed", "not_applicable"].indexOf(harvesting.state) === -1) {
                 completed = false;
             }
         }

--- a/app/templates/src/js/retrieve/templates/harvesting_progress_widget.js
+++ b/app/templates/src/js/retrieve/templates/harvesting_progress_widget.js
@@ -6,6 +6,8 @@ const harvesting_progress_widget = `<li class="list-group-item">
                                     <div class="spinner-border spinner-border-sm ms-auto float-end" aria-hidden="true"></div>
                                 <% } else if(state=="completed") { %>  
                                     <i class="bi bi-check-circle float-end"></i>
+                                <% } else if(state=="not_applicable") { %>  
+                                    <i class="bi bi-question-circle float-end"></i>
                                 <% } else if(state=="canceled") { %>  
                                     <i class="bi bi-slash-circle float-end"></i>
                                 <% } else if(state=="failed") { %>

--- a/identifiers.yml
+++ b/identifiers.yml
@@ -25,3 +25,6 @@
 - key: eppn
   label: EPPN
   priority: 8
+- key: local
+  label: Local
+  priority: 9

--- a/tests/test_api/test_contributions_resolution.py
+++ b/tests/test_api/test_contributions_resolution.py
@@ -49,10 +49,14 @@ async def test_fetch_references_contributions_history(  # pylint: disable=too-ma
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert json_response["harvestings"][0]["harvester"] == "hal"
-        assert len(json_response["harvestings"][0]["reference_events"]) == 7
-        events = json_response["harvestings"][0]["reference_events"]
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
+        assert len(hal_json_harvesting["reference_events"]) == 7
+        events = hal_json_harvesting["reference_events"]
         reference_1_v1_id = _extract_reference_id_by_source_identifier(
             events, "1-will-gain-second-contributor"
         )
@@ -177,8 +181,12 @@ async def test_fetch_references_contributions_history(  # pylint: disable=too-ma
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        events = json_response["harvestings"][0]["reference_events"]
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
+        events = hal_json_harvesting["reference_events"]
         assert len(events) == 7
         reference_1_v2_id = _extract_reference_id_by_source_identifier(
             events, "1-will-gain-second-contributor"
@@ -285,13 +293,11 @@ async def test_fetch_references_contributions_history(  # pylint: disable=too-ma
             reference_3_v1_contributions, 1
         )["contributor"]["last_name"]
         assert any(
-            [
-                variant["first_name"] == previous_first_name
-                and variant["last_name"] == previous_last_name
-                for variant in _extract_contribution_by_rank(
-                    reference_3_v2_contributions, 1
-                )["contributor"]["structured_name_variants"]
-            ]
+            variant["first_name"] == previous_first_name
+            and variant["last_name"] == previous_last_name
+            for variant in _extract_contribution_by_rank(
+                reference_3_v2_contributions, 1
+            )["contributor"]["structured_name_variants"]
         )
         reference_4_v2_id = _extract_reference_id_by_source_identifier(
             events, "4-will-have-a-contributor-keeping-his-name-but-changing-his-id"

--- a/tests/test_api/test_inconsistent_contributors.py
+++ b/tests/test_api/test_inconsistent_contributors.py
@@ -48,10 +48,14 @@ async def test_fetch_references_contributions_history(  # pylint: disable=too-ma
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert json_response["harvestings"][0]["harvester"] == "hal"
-        assert len(json_response["harvestings"][0]["reference_events"]) == 1
-        events = json_response["harvestings"][0]["reference_events"]
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
+        assert len(hal_json_harvesting["reference_events"]) == 1
+        events = hal_json_harvesting["reference_events"]
         reference_event_id = _extract_reference_id_by_source_identifier(
             events, "halshs-02514028"
         )

--- a/tests/test_api/test_references_events_parameter.py
+++ b/tests/test_api/test_references_events_parameter.py
@@ -75,21 +75,23 @@ async def test_fetch_references_async_with_all_event_types(  # pylint: disable=t
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert json_response["harvestings"][0]["harvester"] == "hal"
-        assert len(json_response["harvestings"][0]["reference_events"]) == num_results_1
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
+        assert len(hal_json_harvesting["reference_events"]) == num_results_1
         # all reference events are of type created
         assert all(
             reference_event["type"] == "created"
-            for reference_event in json_response["harvestings"][0]["reference_events"]
+            for reference_event in hal_json_harvesting["reference_events"]
         )
         if "created" in event_types_1:
             assert any(
                 reference_event["reference"]["titles"][0]["value"]
                 == "The metaphorical structuring of kinship in Latin"
-                for reference_event in json_response["harvestings"][0][
-                    "reference_events"
-                ]
+                for reference_event in hal_json_harvesting["reference_events"]
             )
     # 2. Now relaunch the same retrieval with a new version of the results
     with mock.patch.object(aiohttp.ClientSession, "get") as aiohttp_client_session_get:
@@ -113,10 +115,15 @@ async def test_fetch_references_async_with_all_event_types(  # pylint: disable=t
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert json_response["harvestings"][0]["harvester"] == "hal"
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
+        assert hal_json_harvesting["harvester"] == "hal"
         # it has 4 reference events
-        assert len(json_response["harvestings"][0]["reference_events"]) == num_results_2
+        assert len(hal_json_harvesting["reference_events"]) == num_results_2
         # among them, exactly one has the reference
         # with source identifier 1-will-not-change and is unchanged
         if "unchanged" in event_types_2:
@@ -124,9 +131,7 @@ async def test_fetch_references_async_with_all_event_types(  # pylint: disable=t
                 len(
                     [
                         reference_event
-                        for reference_event in json_response["harvestings"][0][
-                            "reference_events"
-                        ]
+                        for reference_event in hal_json_harvesting["reference_events"]
                         if reference_event["reference"]["source_identifier"]
                         == "1-will-not-change"
                         and reference_event["type"] == "unchanged"
@@ -141,9 +146,7 @@ async def test_fetch_references_async_with_all_event_types(  # pylint: disable=t
                 len(
                     [
                         reference_event
-                        for reference_event in json_response["harvestings"][0][
-                            "reference_events"
-                        ]
+                        for reference_event in hal_json_harvesting["reference_events"]
                         if reference_event["reference"]["source_identifier"]
                         == "4-will-appear"
                         and reference_event["type"] == "created"
@@ -158,9 +161,7 @@ async def test_fetch_references_async_with_all_event_types(  # pylint: disable=t
                 len(
                     [
                         reference_event
-                        for reference_event in json_response["harvestings"][0][
-                            "reference_events"
-                        ]
+                        for reference_event in hal_json_harvesting["reference_events"]
                         if reference_event["reference"]["source_identifier"]
                         == "3-will-disappear"
                         and reference_event["type"] == "deleted"
@@ -175,9 +176,7 @@ async def test_fetch_references_async_with_all_event_types(  # pylint: disable=t
                 len(
                     [
                         reference_event
-                        for reference_event in json_response["harvestings"][0][
-                            "reference_events"
-                        ]
+                        for reference_event in hal_json_harvesting["reference_events"]
                         if reference_event["reference"]["source_identifier"]
                         == "2-will-change"
                         and reference_event["type"] == "updated"

--- a/tests/test_api/test_references_history.py
+++ b/tests/test_api/test_references_history.py
@@ -49,13 +49,17 @@ async def test_fetch_references_async_history(  # pylint: disable=too-many-state
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert json_response["harvestings"][0]["harvester"] == "hal"
-        assert len(json_response["harvestings"][0]["reference_events"]) == 3
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
+        assert len(hal_json_harvesting["reference_events"]) == 3
         # all reference events are of type created
         assert all(
             reference_event["type"] == "created"
-            for reference_event in json_response["harvestings"][0]["reference_events"]
+            for reference_event in hal_json_harvesting["reference_events"]
         )
     # 2. Now relaunch the same retrieval
     # It will return a new version of the results
@@ -79,16 +83,19 @@ async def test_fetch_references_async_history(  # pylint: disable=too-many-state
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
         # one and only one "deleted" event occured
         # only for reference with source identifier 3-will-disappear
         assert (
             len(
                 [
                     reference_event
-                    for reference_event in json_response["harvestings"][0][
-                        "reference_events"
-                    ]
+                    for reference_event in hal_json_harvesting["reference_events"]
                     if reference_event["type"] == "deleted"
                     and reference_event["reference"]["source_identifier"]
                     == "3-will-disappear"
@@ -117,10 +124,14 @@ async def test_fetch_references_async_history(  # pylint: disable=too-many-state
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert json_response["harvestings"][0]["harvester"] == "hal"
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
         # there are 3 reference events
-        assert len(json_response["harvestings"][0]["reference_events"]) == 3
+        assert len(hal_json_harvesting["reference_events"]) == 3
         # all of type unchanged
         assert all(
             reference_event["type"] == "unchanged"

--- a/tests/test_api/test_references_with_enhancements.py
+++ b/tests/test_api/test_references_with_enhancements.py
@@ -53,8 +53,13 @@ async def test_fetch_unchanged_references_async_with_enhancements_returned(  # p
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert json_response["harvestings"][0]["harvester"] == "hal"
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
+        assert hal_json_harvesting["harvester"] == "hal"
         # 2. Now increase the version of the harvester
         # and launch a new retrieval with the same person and events
         # It will return the same results as the previous one
@@ -80,20 +85,21 @@ async def test_fetch_unchanged_references_async_with_enhancements_returned(  # p
             response = test_client.get(retrieval_url)
             assert response.status_code == 200
             json_response = response.json()
-            assert json_response["harvestings"][0]["state"] == "completed"
+            # filter harvestings by harvester 'hal'
+            hal_json_harvesting = [
+                h for h in json_response["harvestings"] if h["harvester"] == "hal"
+            ][0]
+            assert hal_json_harvesting is not None
+            assert hal_json_harvesting["state"] == "completed"
             # assert that all 3 references are returned with "enhanced" flag set to true
-            assert len(json_response["harvestings"][0]["reference_events"]) == 3
+            assert len(hal_json_harvesting["reference_events"]) == 3
             assert all(
                 reference_event["type"] == "unchanged"
-                for reference_event in json_response["harvestings"][0][
-                    "reference_events"
-                ]
+                for reference_event in hal_json_harvesting["reference_events"]
             )
             assert all(
                 reference_event["enhanced"]
-                for reference_event in json_response["harvestings"][0][
-                    "reference_events"
-                ]
+                for reference_event in hal_json_harvesting["reference_events"]
             )
 
 
@@ -136,8 +142,13 @@ async def test_fetch_unchanged_references_async_with_enhancements_not_returned( 
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert json_response["harvestings"][0]["harvester"] == "hal"
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
+        assert hal_json_harvesting["harvester"] == "hal"
         # 2. Now increase the version of the harvester
         # and launch a new retrieval with the same person and events
         # It will not return any reference as we don't ask for enhancements
@@ -162,9 +173,14 @@ async def test_fetch_unchanged_references_async_with_enhancements_not_returned( 
             response = test_client.get(retrieval_url)
             assert response.status_code == 200
             json_response = response.json()
-            assert json_response["harvestings"][0]["state"] == "completed"
+            # filter harvestings by harvester 'hal'
+            hal_json_harvesting = [
+                h for h in json_response["harvestings"] if h["harvester"] == "hal"
+            ][0]
+            assert hal_json_harvesting is not None
+            assert hal_json_harvesting["state"] == "completed"
             # assert that no reference is returned
-            assert len(json_response["harvestings"][0]["reference_events"]) == 0
+            assert len(hal_json_harvesting["reference_events"]) == 0
 
 
 @pytest.mark.asyncio
@@ -208,15 +224,19 @@ async def test_fetch_modified_references_async_with_enhancements_returned(  # py
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert json_response["harvestings"][0]["harvester"] == "hal"
-        # 2. Now increase the version of the harvester
-        # and launch a new retrieval with the same person and events
-        # It will return changed results
-        # reference with source_identifier "1-will-not-change" will be unchanged but enhanced
-        # reference with source_identifier "2-will-change" will be updated and enhanced
-        # reference with source_identifier "3-will-disappear" will be marked as deleted (not enhanced)
-        # reference with source_identifier "4-will-appear" will be marked as created (not enhanced)
+        # filter harvestings by harvester 'hal'
+        hal_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "hal"
+        ][0]
+        assert hal_json_harvesting is not None
+        assert hal_json_harvesting["state"] == "completed"
+    # 2. Now increase the version of the harvester
+    # and launch a new retrieval with the same person and events
+    # It will return changed results
+    # reference with source_identifier "1-will-not-change" will be unchanged but enhanced
+    # reference with source_identifier "2-will-change" will be updated and enhanced
+    # reference with source_identifier "3-will-disappear" will be marked as deleted (not enhanced)
+    # reference with source_identifier "4-will-appear" will be marked as created (not enhanced)
     with mock.patch.object(aiohttp.ClientSession, "get") as aiohttp_client_session_get:
         aiohttp_client_session_get.return_value.__aenter__.return_value.status = 200
         aiohttp_client_session_get.return_value.__aenter__.return_value.json.return_value = (
@@ -242,16 +262,19 @@ async def test_fetch_modified_references_async_with_enhancements_returned(  # py
             response = test_client.get(retrieval_url)
             assert response.status_code == 200
             json_response = response.json()
-            assert json_response["harvestings"][0]["state"] == "completed"
+            # filter harvestings by harvester 'hal'
+            hal_json_harvesting = [
+                h for h in json_response["harvestings"] if h["harvester"] == "hal"
+            ][0]
+            assert hal_json_harvesting is not None
+            assert hal_json_harvesting["state"] == "completed"
             # assert that the reference with source_identifier "1-will-not-change"
             # is returned as unchanged with "enhanced" flag set to true
             assert (
                 len(
                     [
                         reference_event
-                        for reference_event in json_response["harvestings"][0][
-                            "reference_events"
-                        ]
+                        for reference_event in hal_json_harvesting["reference_events"]
                         if reference_event["reference"]["source_identifier"]
                         == "1-will-not-change"
                         and reference_event["type"] == "unchanged"
@@ -266,9 +289,7 @@ async def test_fetch_modified_references_async_with_enhancements_returned(  # py
                 len(
                     [
                         reference_event
-                        for reference_event in json_response["harvestings"][0][
-                            "reference_events"
-                        ]
+                        for reference_event in hal_json_harvesting["reference_events"]
                         if reference_event["reference"]["source_identifier"]
                         == "2-will-change"
                         and reference_event["type"] == "updated"
@@ -283,9 +304,7 @@ async def test_fetch_modified_references_async_with_enhancements_returned(  # py
                 len(
                     [
                         reference_event
-                        for reference_event in json_response["harvestings"][0][
-                            "reference_events"
-                        ]
+                        for reference_event in hal_json_harvesting["reference_events"]
                         if reference_event["reference"]["source_identifier"]
                         == "3-will-disappear"
                         and reference_event["type"] == "deleted"
@@ -300,9 +319,7 @@ async def test_fetch_modified_references_async_with_enhancements_returned(  # py
                 len(
                     [
                         reference_event
-                        for reference_event in json_response["harvestings"][0][
-                            "reference_events"
-                        ]
+                        for reference_event in hal_json_harvesting["reference_events"]
                         if reference_event["reference"]["source_identifier"]
                         == "4-will-appear"
                         and reference_event["type"] == "created"

--- a/tests/test_harvesters/test_scanr/test_scanr_harvester.py
+++ b/tests/test_harvesters/test_scanr/test_scanr_harvester.py
@@ -1,6 +1,7 @@
 from unittest import mock
-from elasticsearch import AsyncElasticsearch
+
 import pytest
+from elasticsearch import AsyncElasticsearch
 from fastapi.testclient import TestClient
 
 from app.harvesters.scanr.scanr_harvester import ScanrHarvester
@@ -70,13 +71,17 @@ async def test_fetch_references_async_with_idref(
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["harvester"] == "scanr"
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert len(json_response["harvestings"][0]["reference_events"]) == 1
+        # filter harvestings by harvester 'scanr'
+        scanr_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "scanr"
+        ][0]
+        assert scanr_json_harvesting is not None
+        assert scanr_json_harvesting["state"] == "completed"
+        assert len(scanr_json_harvesting["reference_events"]) == 1
 
         assert all(
             reference_event["type"] == "created"
-            for reference_event in json_response["harvestings"][0]["reference_events"]
+            for reference_event in scanr_json_harvesting["reference_events"]
         )
 
 
@@ -116,11 +121,58 @@ async def test_fetch_references_async_with_orcid(
         response = test_client.get(retrieval_url)
         assert response.status_code == 200
         json_response = response.json()
-        assert json_response["harvestings"][0]["harvester"] == "scanr"
-        assert json_response["harvestings"][0]["state"] == "completed"
-        assert len(json_response["harvestings"][0]["reference_events"]) == 1
+        # filter harvestings by harvester 'scanr'
+        scanr_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "scanr"
+        ][0]
+        assert scanr_json_harvesting is not None
+        assert scanr_json_harvesting["harvester"] == "scanr"
+        assert scanr_json_harvesting["state"] == "completed"
+        assert len(scanr_json_harvesting["reference_events"]) == 1
 
         assert all(
             reference_event["type"] == "created"
-            for reference_event in json_response["harvestings"][0]["reference_events"]
+            for reference_event in scanr_json_harvesting["reference_events"]
         )
+
+
+@pytest.mark.asyncio
+async def test_scanr_harvester_async_not_applicable_with_scopus_eid(
+    test_client: TestClient,
+    person_with_name_and_scopus_eid_json,
+    scanr_api_docs_from_publication,
+):
+    """
+    Test a that the harvester will not run and elasticseacrh will not be queried
+    if submitted with a person with a Scopus EID.
+    """
+
+    with mock.patch.object(
+        AsyncElasticsearch,
+        "search",
+        new=mock.AsyncMock(return_value=scanr_api_docs_from_publication),
+    ):
+        response = test_client.post(
+            REFERENCES_RETRIEVAL_API_PATH,
+            json={
+                "person": person_with_name_and_scopus_eid_json,
+                "events": ["created", "updated", "deleted", "unchanged"],
+                "harvesters": ["scanr"],
+            },
+        )
+
+        assert response.status_code == 200
+        json_response = response.json()
+        retrieval_url = json_response["retrieval_url"]
+        assert retrieval_url is not None
+
+        response = test_client.get(retrieval_url)
+        assert response.status_code == 200
+        json_response = response.json()
+        # filter harvestings by harvester 'scanr'
+        scanr_json_harvesting = [
+            h for h in json_response["harvestings"] if h["harvester"] == "scanr"
+        ][0]
+        assert scanr_json_harvesting is not None
+        assert scanr_json_harvesting["state"] == "not_applicable"
+        assert len(scanr_json_harvesting["reference_events"]) == 0


### PR DESCRIPTION
Send explicit message for "not applicable" harvester when convenient identifiers are not providers